### PR TITLE
Add editable and lineNumbers to plugin config

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ None:
 - [How to use](#how-to-use)
     - [Configure](#configure)
     - [Load the component](#load-the-component)
+    - [Plugin Options](#plugin-options)
 - [Language](#language)
 - [Styling](#styling)
     - [Terminal](#terminal)
@@ -75,6 +76,13 @@ For example add the following in the main file of your website, in your `index.j
 import { defineCustomElements as deckDeckGoHighlightElement } from '@deckdeckgo/highlight-code/dist/loader';
 deckDeckGoHighlightElement();
 ```
+
+### Plugin Options
+| property | type | default |
+|----------|------|---------| 
+| terminal | carbon, ubuntu or none | carbon|
+| editable | boolean | false
+| lineNumbers | boolean | false  |
 
 ## Language
 

--- a/index.js
+++ b/index.js
@@ -5,13 +5,11 @@ const _ = require(`lodash`)
 
 module.exports = ({ markdownAST }, pluginOptions) => {
 
-    const terminal = pluginOptions && pluginOptions.terminal && pluginOptions.terminal !== '' ? pluginOptions.terminal : undefined
-
     visit(markdownAST, "code", node => {
         const text = toString(node)
-
+        const properties = generatePropsString(pluginOptions) 
         const html = `
-        <deckgo-highlight-code ${node && node.lang !== null ? `language="${node.lang}"` : ''} ${terminal !== undefined ? `terminal="${terminal}"` : ''}>
+        <deckgo-highlight-code ${node && node.lang !== null ? `language="${node.lang}"` : ''}  ${properties}>
           <code slot="code">${_.escape(text)}</code>
         </deckgo-highlight-code>
       `
@@ -23,3 +21,26 @@ module.exports = ({ markdownAST }, pluginOptions) => {
 
     return markdownAST
 }
+
+
+function generatePropsString(pluginOptions){
+   if(!pluginOptions){
+     return ""
+   }
+   let str = ""
+   const  {terminal, lineNumbers, editable } = pluginOptions
+
+   if(terminal){
+      str += `terminal="${pluginOptions.terminal}" `    
+   }
+
+   if(lineNumbers === true){
+     str += `line-numbers="true" `
+   }
+
+   if(editable === true) {
+     str+= `editable="true" `
+   }
+   return str
+}
+

--- a/index.js
+++ b/index.js
@@ -23,24 +23,24 @@ module.exports = ({ markdownAST }, pluginOptions) => {
 }
 
 
-function generatePropsString(pluginOptions){
-   if(!pluginOptions){
-     return ""
-   }
-   let str = ""
-   const  {terminal, lineNumbers, editable } = pluginOptions
+function generatePropsString(pluginOptions) {
+  if (!pluginOptions) {
+    return ""
+  }
+  let str = ""
+  const { terminal, lineNumbers, editable } = pluginOptions;
 
-   if(terminal){
-      str += `terminal="${pluginOptions.terminal}" `    
-   }
+  if (terminal) {
+    str += `terminal="${pluginOptions.terminal}" `
+  }
 
-   if(lineNumbers === true){
-     str += `line-numbers="true" `
-   }
+  if (lineNumbers === true) {
+    str += `line-numbers="true" `
+  }
 
-   if(editable === true) {
-     str+= `editable="true" `
-   }
-   return str
+  if (editable === true) {
+    str += `editable="true" `
+  }
+  return str;
 }
 


### PR DESCRIPTION
PR is Related  to  [issue 7](https://github.com/deckgo/gatsby-remark-highlight-code/issues/7). I added config variables for editable and line numbers. What do you think?  
