### PR TITLE
trim the value of html node

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ module.exports = ({ markdownAST }, pluginOptions) => {
         }  ${properties}>
           <code slot="code">${_.escape(text)}</code>
         </deckgo-highlight-code>
-      `;
+      `.trim();
 
     node.type = "html";
     node.children = undefined;


### PR DESCRIPTION
html node value starts with space will generate a <undefined> DOM when working with gatsby-plugin-mdx