### PR TITLE
fix language property to component

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,9 +13,7 @@ module.exports = ({ markdownAST }, pluginOptions) => {
     const text = toString(node);
     const properties = generatePropsString(pluginOptions);
     const html = `
-        <deckgo-highlight-code ${
-          lang
-        }  ${properties} highlight-lines="${highlightLines}">
+        <deckgo-highlight-code language=${lang}  ${properties} highlight-lines="${highlightLines}">
           <code slot="code">${_.escape(text)}</code>
         </deckgo-highlight-code>
       `.trim();


### PR DESCRIPTION
Fixes syntax highlighting for languages other than `js`.

ref: https://docs.deckdeckgo.com/?path=/docs/components-highlight-code--highlight-code

the current code produces something like this. (which causes the component to default to `javascript`)

```html
<deckgo-highlight-code py />
```
Instead of 
```html
<deckgo-highlight-code language=py />
```